### PR TITLE
Resolve Meeting Clashes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/meetings/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetings/AddMeetingCommand.java
@@ -37,6 +37,7 @@ public class AddMeetingCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
     public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in MeetBuddy";
+    public static final String MESSAGE_CLASH_MEETING = "This meeting clashes with an existing meeting %s";
 
     private final Meeting toAdd;
 

--- a/src/main/java/seedu/address/logic/commands/meetings/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/meetings/AddMeetingCommand.java
@@ -14,6 +14,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.meeting.Meeting;
 
+import java.util.List;
+
 
 public class AddMeetingCommand extends Command {
     public static final String COMMAND_WORD = "addm";
@@ -37,7 +39,7 @@ public class AddMeetingCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New meeting added: %1$s";
     public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in MeetBuddy";
-    public static final String MESSAGE_CLASH_MEETING = "This meeting clashes with an existing meeting %s";
+    public static final String MESSAGE_CLASH_MEETING = "This meeting clashes with the following existing meetings \n%s";
 
     private final Meeting toAdd;
 
@@ -55,6 +57,11 @@ public class AddMeetingCommand extends Command {
 
         if (model.hasMeeting(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
+        }
+        if (model.clashes(toAdd)) {
+            List<Meeting> listOfClashingMeetings = model.getClashes(toAdd);
+            String formatMeetingListString = CommandDisplayUtil.formatElementsIntoRows(listOfClashingMeetings);
+            throw new CommandException(String.format(MESSAGE_CLASH_MEETING, formatMeetingListString));
         }
 
         model.addMeeting(toAdd);

--- a/src/main/java/seedu/address/logic/commands/meetings/CommandDisplayUtil.java
+++ b/src/main/java/seedu/address/logic/commands/meetings/CommandDisplayUtil.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands.meetings;
+
+import java.util.List;
+
+public class CommandDisplayUtil {
+
+    /**
+     * Customises the format of the string to display in the command message, instead of relying on the List toString
+     * method.
+     * @return
+     */
+
+    public static String formatElementsIntoRows(List<?> listItems) {
+        String formatString = "";
+        for (Object o : listItems) {
+            formatString += listItems.toString();
+            formatString += "\n";
+        }
+        return formatString;
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,9 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
@@ -136,6 +139,24 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredMeetingList(Predicate<Meeting> predicate);
+
+    // ============= Clashing Meetings  ========================================================
+
+    /**
+     * Checks if there is a clash in meeting times within the model.
+     */
+    public boolean clashes(Meeting toCheck);
+
+    /**
+     * Gets a list of meetings from the model that overlap with this meeting.
+     */
+    public List<Meeting> getClashes(Meeting toCheck);
+
+    /**
+     * Gets the meeting ( if any ) scheduled  at this point in time in the model.
+     */
+    public Optional<Meeting> getMeetingAtInstant(LocalDateTime localDateTime);
+
 
     // ============= PersonMeetingConnection part of the meeting Model interface ================== //
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -106,6 +106,8 @@ public interface Model {
      */
     boolean hasMeeting(Meeting meeting);
 
+
+
     /**
      * Deletes the given meeting.
      * The meeting must exist in the meeting book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,9 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -205,6 +208,29 @@ public class ModelManager implements Model {
         meetingBook.setMeeting(target, editedMeeting);
     }
     //TODO: Set MeetingBook file path in userPrefs? low priority feature(nice to have)
+
+    //========= Clashing Meetings ================================================================
+
+    /**
+     * Checks if there is a clash in meeting times within the model.
+     */
+    public boolean clashes(Meeting toCheck) {
+        return meetingBook.clashes(toCheck);
+    }
+
+    /**
+     * Gets a list of meetings from the model that overlap with this meeting.
+     */
+    public List<Meeting> getClashes(Meeting toCheck) {
+        return meetingBook.getClashes(toCheck);
+    }
+
+    /**
+     * Gets the meeting ( if any ) scheduled  at this point in time in the model.
+     */
+    public Optional<Meeting> getMeetingAtInstant(LocalDateTime localDateTime) {
+        return meetingBook.getMeetingAtInstant(localDateTime);
+    }
 
     // ============= PersonMeetingConnection =======================
     /**

--- a/src/main/java/seedu/address/model/meeting/DateTime.java
+++ b/src/main/java/seedu/address/model/meeting/DateTime.java
@@ -67,11 +67,23 @@ public class DateTime implements Comparable<DateTime> {
 
     /**
      * Converts the dateTime object to localDate.
+     *
      * @return localDate
      */
     public LocalDate toLocalDate() {
         return value.toLocalDate();
     }
+
+    /**
+     * Converts DateTime to LocalDateTime.
+     * @return
+     */
+
+    public LocalDateTime toLocalDateTime() {
+        return value;
+    }
+
+
     @Override
     public int compareTo(DateTime other) {
         if (value.isBefore(other.value)) {

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -151,6 +151,19 @@ public class Meeting implements Schedulable {
         return builder.toString();
     }
 
+    /**
+     * Checks if the meeting is happening at this instant of time.
+     * @param localDateTime
+     * @return
+     */
+
+    public boolean containsTime(LocalDateTime localDateTime) {
+        LocalDateTime startLocalDateTime = start.toLocalDateTime();
+        LocalDateTime endLocalDateTime = terminate.toLocalDateTime();
+        return startLocalDateTime.compareTo(localDateTime) <= 0
+                && endLocalDateTime.compareTo(localDateTime) > 0;
+    }
+
     //==================interface methods =================================================
 
     public LocalDateTime getStartLocalDateTime() {

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -149,4 +149,22 @@ public class Meeting {
         return builder.toString();
     }
 
+    //==================Scheduler methods =================================================
+
+    public LocalDateTime getStartLocalDateTime() {
+        return start.toLocalDateTime();
+    }
+
+    public LocalDateTime getTerminateLocalDateTime() {
+        return terminate.toLocalDateTime();
+    }
+
+    @Override
+    public boolean isConflict(Schedulable schedulable) {
+        return !(this.getStartLocalDateTime().compareTo(schedulable.getTerminateLocalDateTime()) <= 0
+                || this.getStartLocalDateTime().compareTo(schedulable.getTerminateLocalDateTime()) >= 0);
+    }
+
+
+
 }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -151,7 +151,7 @@ public class Meeting implements Schedulable {
         return builder.toString();
     }
 
-    //==================Scheduler methods =================================================
+    //==================interface methods =================================================
 
     public LocalDateTime getStartLocalDateTime() {
         return start.toLocalDateTime();

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -98,7 +98,7 @@ public class Meeting implements Schedulable {
      */
     public static boolean isValidStartTerminate(DateTime start, DateTime terminate) {
         boolean isSameDate = start.toLocalDate().equals(terminate.toLocalDate());
-        return start.compareTo(terminate) == -1 && isSameDate;
+        return start.compareTo(terminate) < 0 && isSameDate;
     }
 
     /**
@@ -167,6 +167,9 @@ public class Meeting implements Schedulable {
                 || this.getStartLocalDateTime().compareTo(schedulable.getTerminateLocalDateTime()) >= 0);
     }
 
-
+    @Override
+    public String getNameString() {
+        return meetingName.fullName;
+    }
 
 }

--- a/src/main/java/seedu/address/model/meeting/Meeting.java
+++ b/src/main/java/seedu/address/model/meeting/Meeting.java
@@ -3,18 +3,20 @@ package seedu.address.model.meeting;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.model.group.Group;
+import seedu.address.model.scheduler.Schedulable;
 
 /**
  * Represents a meeting in MeetBuddy.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Meeting {
+public class Meeting implements Schedulable {
 
     public static final String MESSAGE_CONSTRAINTS =
             "The start date time of a meeting should be strictly earlier than the terminate date time."
@@ -161,7 +163,7 @@ public class Meeting {
 
     @Override
     public boolean isConflict(Schedulable schedulable) {
-        return !(this.getStartLocalDateTime().compareTo(schedulable.getTerminateLocalDateTime()) <= 0
+        return !(this.getTerminateLocalDateTime().compareTo(schedulable.getStartLocalDateTime()) <= 0
                 || this.getStartLocalDateTime().compareTo(schedulable.getTerminateLocalDateTime()) >= 0);
     }
 

--- a/src/main/java/seedu/address/model/meeting/MeetingBook.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingBook.java
@@ -3,7 +3,9 @@ package seedu.address.model.meeting;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 
@@ -88,8 +90,32 @@ public class MeetingBook implements ReadOnlyMeetingBook {
         meetings.remove(key);
     }
 
-    //// util methods
+    // ===================== Clashing meetings checks =================================================
 
+    /**
+     * Checks if there is a clash in Meeting Times within the meeting book.
+     */
+    public boolean clashes(Meeting toCheck) {
+        return meetings.clashes(toCheck);
+    }
+
+    /**
+     * Gets a list of meetings that overlap with this meeting.
+     */
+    public List<Meeting> getClashes(Meeting toCheck) {
+        return meetings.getClashes(toCheck);
+    }
+
+    /**
+     * Gets the meeting ( if any ) happening at this point in time.
+     */
+
+    public Optional<Meeting> getMeetingAtInstant(LocalDateTime localDateTime) {
+        return meetings.getMeetingAtInstant(localDateTime);
+    }
+
+
+    //// ================= Util methods ==============================================
     @Override
     public String toString() {
         return meetings.asUnmodifiableObservableList().size() + " meetings";

--- a/src/main/java/seedu/address/model/meeting/MeetingBook.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingBook.java
@@ -63,6 +63,7 @@ public class MeetingBook implements ReadOnlyMeetingBook {
     /**
      * Adds a meeting to the meeting book.
      * The meeting must not already exist in the meeting book.
+     * The meeting must not clash with any meeting in the meetingBook.
      */
     public void addMeeting(Meeting m) {
         meetings.add(m);

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -5,11 +5,13 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.meeting.exceptions.DuplicateMeetingException;
 import seedu.address.model.meeting.exceptions.MeetingNotFoundException;
+import seedu.address.model.meeting.exceptions.MeetingTimeClashException;
 
 /**
  * A list of meetings that enforces uniqueness between its elements and does not allow nulls.
@@ -38,13 +40,28 @@ public class UniqueMeetingList implements Iterable<Meeting> {
     }
 
     /**
+     * Returns a list of meetings that clash with the current meeting
+     */
+
+    public List<Meeting> getClashes(Meeting toCheck) {
+        requireNonNull(toCheck);
+        return internalList.stream().filter(meeting -> meeting.isConflict(toCheck))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Adds a meeting to the list.
      * The meeting must not already exist in the list.
+     * There must be no clashes with current meeting.
      */
     public void add(Meeting toAdd) {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateMeetingException();
+        }
+        List<Meeting> clashes = getClashes(toAdd);
+        if (clashes.size() > 0) {
+            throw new MeetingTimeClashException(clashes.get(0));
         }
         internalList.add(toAdd);
     }

--- a/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/UniqueMeetingList.java
@@ -39,15 +39,6 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         return internalList.stream().anyMatch(toCheck::isSameMeeting);
     }
 
-    /**
-     * Returns a list of meetings that clash with the current meeting
-     */
-
-    public List<Meeting> getClashes(Meeting toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().filter(meeting -> meeting.isConflict(toCheck))
-                .collect(Collectors.toList());
-    }
 
     /**
      * Adds a meeting to the list.
@@ -58,10 +49,6 @@ public class UniqueMeetingList implements Iterable<Meeting> {
         requireNonNull(toAdd);
         if (contains(toAdd)) {
             throw new DuplicateMeetingException();
-        }
-        List<Meeting> clashes = getClashes(toAdd);
-        if (clashes.size() > 0) {
-            throw new MeetingTimeClashException(clashes.get(0));
         }
         internalList.add(toAdd);
     }

--- a/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
@@ -1,0 +1,13 @@
+package seedu.address.model.meeting.exceptions;
+
+import seedu.address.model.meeting.Meeting;
+
+
+public class MeetingTimeClashException extends RuntimeException {
+    private static final String MEETING_CLASH_MESSAGE = "Already has a meeting inside the meeting list with clashing"
+            + "time.\n\t Meeting that clashes is %s";
+
+    public MeetingTimeClashException(Meeting m) {
+        super(String.format(MEETING_CLASH_MESSAGE, m));
+    }
+}

--- a/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
@@ -7,7 +7,7 @@ public class MeetingTimeClashException extends RuntimeException {
     private static final String MEETING_CLASH_MESSAGE = "Already has a meeting inside the meeting list with clashing "
             + "time.";
 
-    public MeetingTimeClashException(Meeting m) {
+    public MeetingTimeClashException() {
         super(String.format(MEETING_CLASH_MESSAGE));
     }
 }

--- a/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
+++ b/src/main/java/seedu/address/model/meeting/exceptions/MeetingTimeClashException.java
@@ -4,10 +4,10 @@ import seedu.address.model.meeting.Meeting;
 
 
 public class MeetingTimeClashException extends RuntimeException {
-    private static final String MEETING_CLASH_MESSAGE = "Already has a meeting inside the meeting list with clashing"
-            + "time.\n\t Meeting that clashes is %s";
+    private static final String MEETING_CLASH_MESSAGE = "Already has a meeting inside the meeting list with clashing "
+            + "time.";
 
     public MeetingTimeClashException(Meeting m) {
-        super(String.format(MEETING_CLASH_MESSAGE, m));
+        super(String.format(MEETING_CLASH_MESSAGE));
     }
 }

--- a/src/main/java/seedu/address/model/scheduler/Schedulable.java
+++ b/src/main/java/seedu/address/model/scheduler/Schedulable.java
@@ -1,19 +1,32 @@
 package seedu.address.model.scheduler;
 
-import java.util.List;
+
+import java.time.LocalDateTime;
 
 /**
- * Represents objects that can be scheduled in the scheduler. It must have be able to get the timeframe of the object
+ * Represents objects that can be scheduled by the scheduler. A schedulable object has
+ * to have a start date and terminate date.
  */
 
 public interface Schedulable {
 
+    /**
+     * get name of this object.
+     */
+    public String getName();
+
 
     /**
-     * Gets the list of timeframes in which this schedulable is scheduled on.
-     * @return the list of timeframes.
+     * Get the start date time.
+     * @return
      */
-    public List<TimeInterval> getTimeFrame();
+    public LocalDateTime getStartLocalDateTime();
+
+    /**
+     * Get the termination date time.
+     * @return
+     */
+    public LocalDateTime getTerminateLocalDateTime();
 
     /**
      * Given another schedulable object, check if there are any conflicts.

--- a/src/main/java/seedu/address/model/scheduler/Schedulable.java
+++ b/src/main/java/seedu/address/model/scheduler/Schedulable.java
@@ -13,7 +13,7 @@ public interface Schedulable {
     /**
      * get name of this object.
      */
-    public String getName();
+    public String getNameString();
 
 
     /**

--- a/src/main/java/seedu/address/model/scheduler/Scheduler.java
+++ b/src/main/java/seedu/address/model/scheduler/Scheduler.java
@@ -4,17 +4,19 @@ package seedu.address.model.scheduler;
  * This is a class that will manage the scheduling of a set of Schedulable objects.
  */
 
-public interface Scheduler{
+public interface Scheduler {
 
     /**
      * adds a schedulable object to the schedule.
      * @param schedulable
      */
-    public void addToSchedule(Schedulable schedulable);
+    public void addToSchedule(Schedulable schedulable) throws BookingException;
 
     /**
      * deletes a schedulable object from the schedule.
      * @param schedulable
+     * @throws
      */
-    public void freeSchedule(Schedulable schedulable);
+    public void freeSchedule(Schedulable schedulable) throws TimetableAccessException;
+
 }

--- a/src/main/java/seedu/address/model/scheduler/Timetable.java
+++ b/src/main/java/seedu/address/model/scheduler/Timetable.java
@@ -47,12 +47,12 @@ public class Timetable {
      * get the Day schedule corresponding to a localDate;
      * @param localDate
      * @return
-     * @throws TimetableAccessError if the date is not within the timetable.
+     * @throws TimetableAccessException if the date is not within the timetable.
      */
 
-    private DaySchedule getDaySchedule(LocalDate localDate) throws TimetableAccessError {
+    private DaySchedule getDaySchedule(LocalDate localDate) throws TimetableAccessException {
         if (!isDateWithinTimetable(localDate)) {
-            throw new TimetableAccessError(MESSAGE_DAY_NOT_WITHIN_TIMETABLE);
+            throw new TimetableAccessException(MESSAGE_DAY_NOT_WITHIN_TIMETABLE);
         }
         int index = (int) DAYS.between(startOfTheWeek, localDate);
         return weeklySchedule[index];
@@ -76,7 +76,7 @@ public class Timetable {
      * @param endTime
      */
     public void bookTimeRange(LocalDate localDate, LocalTime startTime, LocalTime endTime)
-        throws BookingException, TimetableAccessError {
+        throws BookingException, TimetableAccessException {
         getDaySchedule(localDate).bookTimeRange(startTime, endTime);
     }
 
@@ -85,7 +85,7 @@ public class Timetable {
      * startTime and endTime.
      */
 
-    public void freeTimeRange(LocalDate localDate, LocalTime startTime, LocalTime endTime) throws TimetableAccessError {
+    public void freeTimeRange(LocalDate localDate, LocalTime startTime, LocalTime endTime) throws TimetableAccessException {
         getDaySchedule(localDate).freeTimeRange(startTime, endTime);
     }
 

--- a/src/main/java/seedu/address/model/scheduler/TimetableAccessError.java
+++ b/src/main/java/seedu/address/model/scheduler/TimetableAccessError.java
@@ -1,8 +1,0 @@
-package seedu.address.model.scheduler;
-
-public class TimetableAccessError extends Exception {
-    public TimetableAccessError(String message) {
-        super(message);
-    }
-}
-

--- a/src/main/java/seedu/address/model/scheduler/TimetableAccessException.java
+++ b/src/main/java/seedu/address/model/scheduler/TimetableAccessException.java
@@ -1,0 +1,8 @@
+package seedu.address.model.scheduler;
+
+public class TimetableAccessException extends Exception {
+    public TimetableAccessException(String message) {
+        super(message);
+    }
+}
+

--- a/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandTest.java
@@ -8,8 +8,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -237,6 +240,27 @@ class AddMeetingCommandTest {
         public ObservableList<Person> getFilteredPersonListByMeetingConnection(Meeting meeting) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean clashes(Meeting toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Gets a list of meetings from the model that overlap with this meeting.
+         */
+        public List<Meeting> getClashes(Meeting toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        /**
+         * Gets the meeting ( if any ) scheduled  at this point in time in the model.
+         */
+        public Optional<Meeting> getMeetingAtInstant(LocalDateTime localDateTime) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+
     }
 
     /**
@@ -258,7 +282,7 @@ class AddMeetingCommandTest {
     }
 
     /**
-     * A Model stub that always accept the person being added.
+     * A Model stub that always accept the meeting being added.
      */
     private class MeetingModelStubAcceptingAdded extends AddMeetingCommandTest.ModelStub {
         final ArrayList<Meeting> meetingsAdded = new ArrayList<>();
@@ -273,6 +297,11 @@ class AddMeetingCommandTest {
         public void addMeeting(Meeting meeting) {
             requireNonNull(meeting);
             meetingsAdded.add(meeting);
+        }
+        @Override
+        public boolean clashes(Meeting meeting) {
+            requireNonNull(meeting);
+            return meetingsAdded.stream().anyMatch(meeting :: isConflict);
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/persons/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/persons/AddPersonCommandTest.java
@@ -7,8 +7,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -235,6 +238,21 @@ public class AddPersonCommandTest {
 
         @Override
         public ObservableList<Person> getFilteredPersonListByMeetingConnection(Meeting meeting) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean clashes(Meeting toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public List<Meeting> getClashes(Meeting toCheck) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Optional<Meeting> getMeetingAtInstant(LocalDateTime localDateTime) {
             throw new AssertionError("This method should not be called.");
         }
     }


### PR DESCRIPTION
Previously, meetings that happen on the same date are allowed to be added.
 
As a meeting planner it is critical that meetings cannot clash.

Therefore these are the changes

- UniqueMeetingList cannot contain clashing meetings.
- Model has extra methods to check for clashing meetings, get meetings that clash
- AddMeetingCommand will throw exception when clashing meeting is added
- A helpful display command with all the clashing meetings will be displayed.



