### PR TITLE
Branch responsive date column

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,7 +1,9 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
@@ -65,4 +67,10 @@ public interface Logic {
      * Gets the internal unmodifiable Observable list of all meetings inside meeting book
      */
     ObservableList<Meeting> getAllMeetingList();
+
+    /**
+     * Gets the observable value of the timetable start date.
+     * @return
+     */
+    public ObservableValue<LocalDate> getTimeTableStartDate();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -2,8 +2,10 @@ package seedu.address.logic;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -91,10 +93,15 @@ public class LogicManager implements Logic {
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
     }
-    //======================================Ui methods ============================================
+    //======================================Timetable UI methods ============================================
 
     @Override
     public ObservableList<Meeting> getAllMeetingList() {
         return model.getUnmodifiableMeetingList();
     }
+    @Override
+    public ObservableValue<LocalDate> getTimeTableStartDate() {
+        return model.getReadOnlyTimetableStartDate();
+    }
 }
+

--- a/src/main/java/seedu/address/logic/parser/DateTimeUtil.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -17,7 +18,7 @@ public class DateTimeUtil {
     public static final DateTimeFormatter ISO_DATE_FORMATTER_NO_SECONDS =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
 
-    public static final DateTimeFormatter PRETTY_DATE_FORMATTER =
+    public static final DateTimeFormatter PRETTY_DATETIME_FORMATTER =
             DateTimeFormatter.ofPattern("dd MMM yyyy, eeee, h:mm a");
 
     public static final DateTimeFormatter ISO_TIME_FORMATTER_NO_SECONDS =
@@ -25,6 +26,9 @@ public class DateTimeUtil {
 
     public static final DateTimeFormatter PRETTY_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("h:mm a");
+
+    public static final DateTimeFormatter PRETTY_DATE_FORMATTER =
+            DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     /**
      * Formats a LocalDateTime object into the appropriate ISO string, with the seconds
@@ -57,7 +61,7 @@ public class DateTimeUtil {
      * @return the formatted string
      */
     public static String prettyPrintFormatDateTime(LocalDateTime dateTime) {
-        return dateTime.format(PRETTY_DATE_FORMATTER);
+        return dateTime.format(PRETTY_DATETIME_FORMATTER);
     }
 
     public static String isoFormatTime(LocalTime localTime) {
@@ -66,6 +70,9 @@ public class DateTimeUtil {
 
     public static String prettyPrintFormatLocalTime(LocalTime localTime) {
         return localTime.format(PRETTY_TIME_FORMATTER);
+    }
+    public static String prettuPrintFormatLocalDate(LocalDate localDate) {
+        return localDate.format(PRETTY_DATE_FORMATTER);
     }
 
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -8,6 +9,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.connection.PersonMeetingConnection;
@@ -221,6 +223,20 @@ public interface Model {
      */
     ObservableList<Person> getFilteredPersonListByMeetingConnection(Meeting meeting);
 
+
+    //============================= Timetable settings =====================================
+
+    /**
+     * sets the timetable start date.
+     * @param localDate
+     */
+    public void setTimetableStartDate(LocalDate localDate);
+
+    /**
+     * Get a read-only observable for the timetable start date.
+     * @return the observable value of the start date.
+     */
+    public ObservableValue<LocalDate> getReadOnlyTimetableStartDate();
 
     // ------ Reminders ------
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -13,6 +14,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
@@ -30,6 +32,7 @@ import seedu.address.model.person.ReadOnlyAddressBook;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.reminder.ReadOnlyReminderBook;
 import seedu.address.model.reminder.ReminderBook;
+import seedu.address.model.schedule.TimetablePrefs;
 
 /**
  * Represents the in-memory model of the address book data.
@@ -52,6 +55,9 @@ public class ModelManager implements Model {
 
     private final ReminderBook reminderBook;
 
+    //===============  Timetable ===========================================================
+    private final TimetablePrefs timetablePrefs;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs. MeetingBook will be set to default.
      */
@@ -72,6 +78,10 @@ public class ModelManager implements Model {
         // TODO: Modify the signature of ModelManager so that we can add connection inside it.
         this.connection = new PersonMeetingConnection();
         this.reminderBook = new ReminderBook(this.meetingBook);
+
+        //================== Timetable ==================================================================
+        //default initializes to current localdate
+        timetablePrefs = new TimetablePrefs(LocalDate.now());
     }
 
     /**
@@ -95,6 +105,10 @@ public class ModelManager implements Model {
         // TODO: Modify the signature of ModelManager so that we can add connection inside it.
         this.connection = new PersonMeetingConnection();
         this.reminderBook = new ReminderBook(this.meetingBook);
+
+        //================== Timetable ==================================================================
+        //default initializes to current localdate
+        timetablePrefs = new TimetablePrefs(LocalDate.now());
     }
 
     /**
@@ -118,6 +132,9 @@ public class ModelManager implements Model {
         // TODO: Modify the signature of ModelManager so that we can add connection inside it.
         this.connection = connection;
         this.reminderBook = new ReminderBook(this.meetingBook);
+        //================== Timetable ==================================================================
+        //default initializes to current localdate
+        timetablePrefs = new TimetablePrefs(LocalDate.now());
 
     }
 
@@ -406,6 +423,19 @@ public class ModelManager implements Model {
     public void sortFilteredMeetingList(Comparator<Meeting> comparator) {
         sortedBeforeFilterMeetings.setComparator(comparator);
     }
+
+    //================= Get timetable prefs methods ================================================
+
+    @Override
+    public void setTimetableStartDate(LocalDate localDate) {
+        timetablePrefs.setTimetableStartDate(localDate);
+    }
+
+    @Override
+    public ObservableValue<LocalDate> getReadOnlyTimetableStartDate() {
+        return timetablePrefs.getReadOnlyStartDate();
+    }
+
 
     //=========== Other methods =============================================================
     @Override

--- a/src/main/java/seedu/address/model/schedule/TimetablePrefs.java
+++ b/src/main/java/seedu/address/model/schedule/TimetablePrefs.java
@@ -25,7 +25,7 @@ public class TimetablePrefs {
     }
 
     /**
-     * Returns the Read-Only timetable start date wrapped in Observable value wrapper.
+     * Returns the timetable start date wrapped in Observable value wrapper.
      */
     public ObservableValue<LocalDate> getReadOnlyStartDate() {
         return timetableStartDate;

--- a/src/main/java/seedu/address/model/schedule/TimetablePrefs.java
+++ b/src/main/java/seedu/address/model/schedule/TimetablePrefs.java
@@ -1,0 +1,35 @@
+package seedu.address.model.schedule;
+
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ObservableValue;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class TimetablePrefs {
+    private final SimpleObjectProperty<LocalDate> timetableStartDate;
+
+    /**
+     * Default initialises the timetableStartDate to the localDate.
+     */
+    public TimetablePrefs(LocalDate localDate) {
+        timetableStartDate = new SimpleObjectProperty<LocalDate>(localDate);
+    }
+
+
+    /**
+     * Sets the timetableStartDate to a specified date.
+     */
+    public void setTimetableStartDate(LocalDate localDate) {
+        timetableStartDate.setValue(localDate);
+    }
+
+    /**
+     * Returns the Read-Only timetable start date wrapped in Observable value wrapper.
+     */
+    public ObservableValue<LocalDate> getReadOnlyStartDate() {
+        return timetableStartDate;
+    }
+
+}
+

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -150,7 +150,7 @@ public class MainWindow extends UiPart<Stage> {
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
         ObservableList<Meeting> meetingObservableList = logic.getAllMeetingList();
-        TimetableView timetableView = new TimetableView(meetingObservableList, LocalDate.now());
+        TimetableView timetableView = new TimetableView(meetingObservableList, logic.getTimeTableStartDate());
         timetableHolder.getChildren().add(timetableView.getRoot());
 
         // Yuheng To Maurice: I made my modification to the logic so now you can add meetings into the UI.

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -149,12 +149,6 @@ public class MainWindow extends UiPart<Stage> {
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
-        /**List<Meeting> listm = new ArrayList<>();
-        ObservableList<Meeting> meetingObservableList = FXCollections.observableList(listm);
-        listm.add(MEETING1);
-        listm.add(MEETING2);
-        listm.add(MEETING3);
-         */
         ObservableList<Meeting> meetingObservableList = logic.getAllMeetingList();
         TimetableView timetableView = new TimetableView(meetingObservableList, LocalDate.now());
         timetableHolder.getChildren().add(timetableView.getRoot());

--- a/src/main/java/seedu/address/ui/TimetablePlacementPolicy.java
+++ b/src/main/java/seedu/address/ui/TimetablePlacementPolicy.java
@@ -145,7 +145,7 @@ public class TimetablePlacementPolicy {
      * @return
      */
 
-    public Stream<Schedulable> breakIntoUnits(Schedulable schedulable) {
+    public Stream<Schedulable> breakIntoDayUnits(Schedulable schedulable) {
 
         assert test(schedulable);
         LocalDateTime startDateTime = schedulable.getStartLocalDateTime();
@@ -195,20 +195,28 @@ public class TimetablePlacementPolicy {
     }
 
     /**
-     * apply offset so each day period starts from 00:00 and ends at LocalTime.max the next day.
+     * apply offset start hour and start minutes so each day period starts from 00:00 and ends at LocalTime.max the
+     * next day.
      * @param localDateTime
      * @return
      */
     public LocalDateTime applyOffset(LocalDateTime localDateTime) {
         return localDateTime.minusHours(startHour).minusMinutes(startMinute);
     }
-    public LocalDateTime removeOffset(LocalDateTime localDateTime) {
-        return localDateTime.plusHours(startHour).plusMinutes(startMinute);
+
+    /**
+     * remove the offset on a date Time which has previously been offset by amount startHour and startminute
+     * in @code{applyOffset}
+     *
+     * @param offSetDateTime
+     * @return
+     */
+    public LocalDateTime removeOffset(LocalDateTime offSetDateTime) {
+        return offSetDateTime.plusHours(startHour).plusMinutes(startMinute);
     }
 
     /**
-     * Gets the local date time of the (official) start of the next day, with time at LocalTime.max
-     * given the date today.
+     * Gets the local date time of the end of the day, right before 00:00.
      * @return
      */
     public LocalDateTime getEndOfTheDay(LocalDateTime localDateTime) {

--- a/src/main/java/seedu/address/ui/TimetableView.java
+++ b/src/main/java/seedu/address/ui/TimetableView.java
@@ -30,7 +30,7 @@ public class TimetableView extends UiPart<Region> {
     private static final String FXML = "TimetableWindow.fxml";
 
     private final Logger logger = LogsCenter.getLogger(TimetableView.class);
-    private final ListChangeListener<Schedulable> listener = change -> {
+    private final ListChangeListener<Schedulable> meetingsListener = change -> {
         while (change.next()) {
             if (change.wasAdded() || change.wasRemoved()) {
                 this.populateWithData(change.getList());
@@ -98,7 +98,7 @@ public class TimetableView extends UiPart<Region> {
         this.timetablePlacementPolicy = new TimetablePlacementPolicy(firstDayOfTimetable);
         populateWithData(timetableSlots);
         //add Listener
-        timetableSlots.addListener(this.listener);
+        timetableSlots.addListener(this.meetingsListener);
     }
 
     public void setTimetablePlacementPolicy(TimetablePlacementPolicy policy) {
@@ -114,7 +114,7 @@ public class TimetableView extends UiPart<Region> {
         reset();
         List<? extends Schedulable> processedList = obsList.stream()
                 .filter(timetablePlacementPolicy :: test)
-                .flatMap(timetablePlacementPolicy :: breakIntoUnits)
+                .flatMap(timetablePlacementPolicy :: breakIntoDayUnits)
                 .collect(Collectors.toList());
         for (Schedulable schedulable : processedList) {
             double slotLength = timetablePlacementPolicy.getLengthOfSlot(schedulable);

--- a/src/main/java/seedu/address/ui/TimetableView.java
+++ b/src/main/java/seedu/address/ui/TimetableView.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -30,13 +32,6 @@ public class TimetableView extends UiPart<Region> {
     private static final String FXML = "TimetableWindow.fxml";
 
     private final Logger logger = LogsCenter.getLogger(TimetableView.class);
-    private final ListChangeListener<Schedulable> meetingsListener = change -> {
-        while (change.next()) {
-            if (change.wasAdded() || change.wasRemoved()) {
-                this.populateWithData(change.getList());
-            }
-        }
-    };
 
 
     @FXML
@@ -73,7 +68,21 @@ public class TimetableView extends UiPart<Region> {
 
     private ObservableList<? extends Schedulable> timetableSlots;
 
-    private LocalDate firstDayOfTimetable;
+    private ObservableValue<LocalDate> firstDayOfTimetable;
+
+    private final ListChangeListener<Schedulable> meetingsListener = change -> {
+        while (change.next()) {
+            if (change.wasAdded() || change.wasRemoved()) {
+                this.populateWithData(change.getList());
+            }
+        }
+    };
+
+    private final ChangeListener<LocalDate> dateListener = (observable, oldValue, newValue) -> {
+        reset();
+        timetablePlacementPolicy = new TimetablePlacementPolicy(newValue);
+        populateWithData(timetableSlots);
+    };
 
 
     /**
@@ -91,14 +100,16 @@ public class TimetableView extends UiPart<Region> {
      * @param timetableSlots
      */
 
-    public TimetableView(ObservableList<? extends Schedulable> timetableSlots, LocalDate firstDayOfTimetable) {
+    public TimetableView(ObservableList<? extends Schedulable> timetableSlots,
+                         ObservableValue<LocalDate> firstDayOfTimetable) {
         super(FXML);
         this.timetableSlots = timetableSlots;
         this.firstDayOfTimetable = firstDayOfTimetable;
-        this.timetablePlacementPolicy = new TimetablePlacementPolicy(firstDayOfTimetable);
+        this.timetablePlacementPolicy = new TimetablePlacementPolicy(firstDayOfTimetable.getValue());
         populateWithData(timetableSlots);
         //add Listener
         timetableSlots.addListener(this.meetingsListener);
+        firstDayOfTimetable.addListener(this.dateListener);
     }
 
     public void setTimetablePlacementPolicy(TimetablePlacementPolicy policy) {
@@ -208,5 +219,7 @@ public class TimetableView extends UiPart<Region> {
         dayScheduleSix.getChildren().clear();
         dayScheduleSeven.getChildren().clear();
     }
+
+
 
 }

--- a/src/main/java/seedu/address/ui/TimetableView.java
+++ b/src/main/java/seedu/address/ui/TimetableView.java
@@ -249,13 +249,25 @@ public class TimetableView extends UiPart<Region> {
      * on the currentDate.
      */
     public void refreshDayLabels(LocalDate currentDate) {
-        firstDayLabel.setText(currentDate.getDayOfWeek().name());
-        secondDayLabel.setText(currentDate.plusDays(1).getDayOfWeek().name());
-        thirdDayLabel.setText(currentDate.plusDays(2).getDayOfWeek().name());
-        fourthDayLabel.setText(currentDate.plusDays(3).getDayOfWeek().name());
-        fifthDayLabel.setText(currentDate.plusDays(4).getDayOfWeek().name());
-        sixthDayLabel.setText(currentDate.plusDays(5).getDayOfWeek().name());
-        seventhDayLabel.setText(currentDate.plusDays(6).getDayOfWeek().name());
+        firstDayLabel.setText(generateDayLabel(currentDate));
+        secondDayLabel.setText(generateDayLabel(currentDate.plusDays(1)));
+        thirdDayLabel.setText(generateDayLabel(currentDate.plusDays(2)));
+        fourthDayLabel.setText(generateDayLabel(currentDate.plusDays(3)));
+        fifthDayLabel.setText(generateDayLabel(currentDate.plusDays(4)));
+        sixthDayLabel.setText(generateDayLabel(currentDate.plusDays(5)));
+        seventhDayLabel.setText(generateDayLabel(currentDate.plusDays(6)));
+    }
+
+    /**
+     * generate a nicely formatted String to display on the column headers
+     * @param date the date corresponding to the column to generate the header for
+     * @return
+     */
+
+    public String generateDayLabel(LocalDate date) {
+        return DateTimeUtil.prettuPrintFormatLocalDate(date)
+                + "\n"
+                + date.getDayOfWeek().name();
     }
 
 

--- a/src/main/java/seedu/address/ui/TimetableView.java
+++ b/src/main/java/seedu/address/ui/TimetableView.java
@@ -12,6 +12,7 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 
+import javafx.scene.control.Label;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
@@ -58,6 +59,27 @@ public class TimetableView extends UiPart<Region> {
     @FXML
     private AnchorPane dayScheduleSeven;
 
+    @FXML
+    private Label firstDayLabel;
+
+    @FXML
+    private Label secondDayLabel;
+
+    @FXML
+    private Label thirdDayLabel;
+
+    @FXML
+    private Label fourthDayLabel;
+
+    @FXML
+    private Label fifthDayLabel;
+
+    @FXML
+    private Label sixthDayLabel;
+
+    @FXML
+    private Label seventhDayLabel;
+
 
     /**
      * Using strategy pattern. Logic for implementing timetable.
@@ -79,9 +101,10 @@ public class TimetableView extends UiPart<Region> {
     };
 
     private final ChangeListener<LocalDate> dateListener = (observable, oldValue, newValue) -> {
-        reset();
+        resetColumns();
         timetablePlacementPolicy = new TimetablePlacementPolicy(newValue);
         populateWithData(timetableSlots);
+        refreshDayLabels(newValue);
     };
 
 
@@ -107,6 +130,7 @@ public class TimetableView extends UiPart<Region> {
         this.firstDayOfTimetable = firstDayOfTimetable;
         this.timetablePlacementPolicy = new TimetablePlacementPolicy(firstDayOfTimetable.getValue());
         populateWithData(timetableSlots);
+        refreshDayLabels(firstDayOfTimetable.getValue());
         //add Listener
         timetableSlots.addListener(this.meetingsListener);
         firstDayOfTimetable.addListener(this.dateListener);
@@ -122,7 +146,7 @@ public class TimetableView extends UiPart<Region> {
      */
 
     public void populateWithData(ObservableList<? extends Schedulable> obsList) {
-        reset();
+        resetColumns();
         List<? extends Schedulable> processedList = obsList.stream()
                 .filter(timetablePlacementPolicy :: test)
                 .flatMap(timetablePlacementPolicy :: breakIntoDayUnits)
@@ -210,7 +234,7 @@ public class TimetableView extends UiPart<Region> {
     /**
      * resets to an empty timetable.
      */
-    public void reset() {
+    public void resetColumns() {
         dayScheduleOne.getChildren().clear();
         dayScheduleTwo.getChildren().clear();
         dayScheduleThree.getChildren().clear();
@@ -219,6 +243,22 @@ public class TimetableView extends UiPart<Region> {
         dayScheduleSix.getChildren().clear();
         dayScheduleSeven.getChildren().clear();
     }
+
+    /**
+     * refreshes all day header labels display day of the week starting
+     * on the currentDate.
+     */
+    public void refreshDayLabels(LocalDate currentDate) {
+        firstDayLabel.setText(currentDate.getDayOfWeek().name());
+        secondDayLabel.setText(currentDate.plusDays(1).getDayOfWeek().name());
+        thirdDayLabel.setText(currentDate.plusDays(2).getDayOfWeek().name());
+        fourthDayLabel.setText(currentDate.plusDays(3).getDayOfWeek().name());
+        fifthDayLabel.setText(currentDate.plusDays(4).getDayOfWeek().name());
+        sixthDayLabel.setText(currentDate.plusDays(5).getDayOfWeek().name());
+        seventhDayLabel.setText(currentDate.plusDays(6).getDayOfWeek().name());
+    }
+
+
 
 
 

--- a/src/main/resources/view/TimetableWindow.fxml
+++ b/src/main/resources/view/TimetableWindow.fxml
@@ -32,7 +32,7 @@
                <children>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.vgrow="ALWAYS">
                      <children>
-                        <Label text="Monday" textAlignment="CENTER" textFill="#6f387c">
+                        <Label fx:id="firstDayLabel" text="Monday" textAlignment="CENTER" textFill="#6f387c">
                            <font>
                               <Font name="Corsiva Hebrew" size="13.0" />
                            </font>
@@ -44,7 +44,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="1" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Tuesday" textAlignment="CENTER" textFill="#89558a">
+                        <Label fx:id="secondDayLabel" text="Tuesday" textAlignment="CENTER" textFill="#89558a">
                            <effect>
                               <Glow />
                            </effect>
@@ -53,7 +53,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="2" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Wednesday" textAlignment="CENTER" textFill="#844c90">
+                        <Label fx:id="thirdDayLabel" text="Wednesday" textAlignment="CENTER" textFill="#844c90">
                            <effect>
                               <Glow />
                            </effect>
@@ -62,7 +62,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="3" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Thursday" textAlignment="CENTER" textFill="#8d4a90">
+                        <Label fx:id="fourthDayLabel" text="Thursday" textAlignment="CENTER" textFill="#8d4a90">
                            <effect>
                               <Glow />
                            </effect>
@@ -71,7 +71,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="4" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Friday" textAlignment="CENTER" textFill="#6e4275">
+                        <Label fx:id="fifthDayLabel" text="Friday" textAlignment="CENTER" textFill="#6e4275">
                            <effect>
                               <Glow />
                            </effect>
@@ -80,7 +80,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="5" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Saturday" textAlignment="CENTER" textFill="#a4499a">
+                        <Label fx:id="sixthDayLabel" text="Saturday" textAlignment="CENTER" textFill="#a4499a">
                            <effect>
                               <Glow />
                            </effect>
@@ -89,7 +89,7 @@
                   </VBox>
                   <VBox alignment="CENTER" prefHeight="200.0" GridPane.columnIndex="6" GridPane.hgrow="ALWAYS">
                      <children>
-                        <Label text="Sunday" textAlignment="CENTER" textFill="#793e72">
+                        <Label fx:id="seventhDayLabel" text="Sunday" textAlignment="CENTER" textFill="#793e72">
                            <effect>
                               <Glow />
                            </effect>

--- a/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -17,6 +18,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javafx.beans.value.ObservableValue;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
@@ -265,10 +267,26 @@ class AddMeetingCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        //=======================Timetable methods ================================================
+
         @Override
         public ObservableList<Person> getFilteredPersonListByMeetingConnection(Meeting meeting) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void setTimetableStartDate(LocalDate localDate) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public ObservableValue<LocalDate> getReadOnlyTimetableStartDate() {
+            throw new AssertionError("This method should not be called");
+        }
+
+        //-============================================================================================
+
+
 
         @Override
         public ReadOnlyReminderBook getReminderBook() {

--- a/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandWithConnectionTest.java
+++ b/src/test/java/seedu/address/logic/commands/meetings/AddMeetingCommandWithConnectionTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands.meetings;
 
+import javafx.beans.value.ObservableValue;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import org.junit.jupiter.api.Test;
@@ -22,10 +23,12 @@ import seedu.address.model.person.ReadOnlyAddressBook;
 import seedu.address.model.person.UniquePersonList;
 import seedu.address.model.reminder.ReadOnlyReminderBook;
 import seedu.address.model.reminder.ReminderBook;
+import seedu.address.model.schedule.TimetablePrefs;
 import seedu.address.testutil.MeetingBuilder;
 import seedu.address.testutil.PersonBuilder;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -125,6 +128,8 @@ public class AddMeetingCommandWithConnectionTest {
         // TODO: Modify the signature of ModelManager so that we can add connection inside it.
         private final PersonMeetingConnection connection;
 
+        private final TimetablePrefs timetablePrefs;
+
 
         /**
          * Initializes a ModelManager with the given addressBook, meetingBOok and userPrefs
@@ -141,6 +146,7 @@ public class AddMeetingCommandWithConnectionTest {
             filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
             // TODO: Modify the signature of ModelManager so that we can add connection inside it.
             this.connection = new PersonMeetingConnection();
+            this.timetablePrefs = new TimetablePrefs(LocalDate.of(2020,10,10));
         }
 
 
@@ -424,10 +430,23 @@ public class AddMeetingCommandWithConnectionTest {
 
         }
 
+        //======================= Timetable methods ========================================
+
+        @Override
+        public void setTimetableStartDate(LocalDate localDate) {
+            timetablePrefs.setTimetableStartDate(localDate);
+        }
+
+        @Override
+        public ObservableValue<LocalDate> getReadOnlyTimetableStartDate() {
+            return timetablePrefs.getReadOnlyStartDate();
+        }
+
         @Override
         public ObservableList<Meeting> getUnmodifiableMeetingList() {
             return meetingBook.getMeetingList();
         }
+
 
     }
 }

--- a/src/test/java/seedu/address/logic/commands/persons/AddPersonCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/persons/AddPersonCommandTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.nio.file.Path;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import javafx.beans.value.ObservableValue;
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
@@ -265,10 +267,23 @@ public class AddPersonCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        //=========================== Timetable methods =============================
+
         @Override
         public ObservableList<Person> getFilteredPersonListByMeetingConnection(Meeting meeting) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public void setTimetableStartDate(LocalDate localDate) {
+            throw new AssertionError("This method should not be called");
+        }
+
+        @Override
+        public ObservableValue<LocalDate> getReadOnlyTimetableStartDate() {
+            throw new AssertionError("This method should not be called");
+        }
+        //==========================================================================================
 
         @Override
         public ReadOnlyReminderBook getReminderBook() {


### PR DESCRIPTION
When starting the timetable, it should display all the column headers correctly

For example if you start the application on 31-03-2021, 
the column header should accurately reflect todays date,
and the first column should display todays date and the day


